### PR TITLE
Issue #13 Support broker authentication

### DIFF
--- a/pinotdb/db.py
+++ b/pinotdb/db.py
@@ -188,6 +188,8 @@ class Cursor(object):
         port=8099,
         scheme="http",
         path="/query/sql",
+        username=None,
+        password=None,
         extra_request_headers="",
         debug=False,
         preserve_types=False,
@@ -220,6 +222,7 @@ class Cursor(object):
             self._ignore_exception_error_codes = []
             
         self.session = requests.Session()
+        self.session.auth = (username, password)
         self.session.headers.update({"Content-Type": "application/json"})
         
         extra_headers = {}

--- a/pinotdb/sqlalchemy.py
+++ b/pinotdb/sqlalchemy.py
@@ -147,6 +147,8 @@ class PinotDialect(default.DefaultDialect):
             "port": url.port or 9000,
             "path": url.database,
             "scheme": self.scheme,
+            "username": url.username,
+            "password": url.password,
         }
         if url.query:
             kwargs.update(url.query)


### PR DESCRIPTION
Resolves #13
- [sqlalchemy parses username and password from URL](https://github.com/zzzeek/sqlalchemy/blob/master/lib/sqlalchemy/engine/url.py#L699).
- [Currently not being used by PinotDialect however](https://github.com/python-pinot-dbapi/pinot-dbapi/blob/master/pinotdb/sqlalchemy.py#L144).
- Added it to the args and then set the session auth [as recommended](https://docs.python-requests.org/en/master/user/advanced/).

Tested:
- Created the .tar.gz locally and tested with locally running Pinot / Superset.
- Works when there is no username / password provided as well.