### PR TITLE
Add httpx to install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ AUTHOR = 'Beto Dealmeida, Devesh Agrawal'
 
 # What packages are required for this module to be executed?
 REQUIRED = [
+    'httpx',
     'requests',
     'six',
 ]


### PR DESCRIPTION
I believe this was missed in:
https://github.com/python-pinot-dbapi/pinot-dbapi/pull/28
and a test import without this package fails.

closes #32 