### PR TITLE
add ability to pass in QueryOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ Current supported Pinot version: 0.9.3.
 ```python
 from pinotdb import connect
 
-conn = connect(host='localhost', port=8099, path='/query/sql', scheme='http')
+# this assumes 9000 is the controller port
+conn = connect(host='localhost', port=9000, path='/sql', scheme='http')
 curs = conn.cursor()
 curs.execute("""
     SELECT place,
@@ -29,7 +30,8 @@ For HTTPS:
 ```python
 from pinotdb import connect
 
-conn = connect(host='localhost', port=443, path='/query/sql', scheme='https')
+# this assumes that 443 is the controller port
+conn = connect(host='localhost', port=443, path='/sql', scheme='https')
 curs = conn.cursor()
 curs.execute("""
     SELECT place,
@@ -46,6 +48,12 @@ Pinot also supports basic auth, e.g.
 
 ```python
 conn = connect(host="localhost", port=443, path="/query/sql", scheme="https", username="my-user", password="my-password", verify_ssl=True)
+```
+
+To pass in additional query parameters (such as `useMultistageEngine=true`) you may pass
+them in as part of the `execute` method. For example:
+```python
+curs.execute("select * from airlineStats air limit 10", queryOptions="useMultistageEngine=true")
 ```
 
 ### Using SQLAlchemy:

--- a/pinotdb/db.py
+++ b/pinotdb/db.py
@@ -376,12 +376,16 @@ class Cursor(object):
                 f" {responded} responded, while needed was {needed}"
             )
 
-    def finalize_query_payload(self, operation, parameters=None):
+    def finalize_query_payload(self, operation, parameters=None, queryOptions=None):
         query = apply_parameters(operation, parameters or {})
 
         if self._preserve_types:
             query += " OPTION(preserveType='true')"
-        return {"sql": query}
+
+        if queryOptions:
+            return {"sql": query, "queryOptions": queryOptions}
+        else:
+            return {"sql": query}
 
     def normalize_query_response(self, input_query, query_response):
         try:
@@ -448,8 +452,8 @@ class Cursor(object):
 
 
     @check_closed
-    def execute(self, operation, parameters=None, **kwargs):
-        query = self.finalize_query_payload(operation, parameters)
+    def execute(self, operation, parameters=None, queryOptions=None, **kwargs):
+        query = self.finalize_query_payload(operation, parameters, queryOptions)
 
         if self.auth and self.auth._username and self.auth._password:
             r = self.session.post(
@@ -541,8 +545,8 @@ class Cursor(object):
 
 class AsyncCursor(Cursor):
     @check_closed
-    async def execute(self, operation, parameters=None, **kwargs):
-        query = self.finalize_query_payload(operation, parameters)
+    async def execute(self, operation, parameters=None, queryOptions=None, **kwargs):
+        query = self.finalize_query_payload(operation, parameters, queryOptions)
 
         if self.auth and self.auth._username and self.auth._password:
             r = await self.session.post(


### PR DESCRIPTION
previously it was not possible to pass in query options that need to be passed in the JSON payload request, this enables that functionality and makes the README more user friendly