### PR TITLE
Prevent parsing None fields

### DIFF
--- a/pinotdb/db.py
+++ b/pinotdb/db.py
@@ -267,7 +267,8 @@ def convert_result_if_required(data_types, rows):
     for i, t in enumerate(data_types):
         if t.needs_conversion:
             for row in rows:
-                row[i] = convert_result(t, json.dumps(row[i]))
+                if row[i] is not None:
+                    row[i] = convert_result(t, json.dumps(row[i]))
     return rows
 
 


### PR DESCRIPTION
When null handling is enabled in the query, the field can be returned as `None`. Parsing `None` into a python date leads to an exception.