### PR TITLE
Allow previous versions of ciso8601 and requests, Unit test for null handling

### DIFF
--- a/pinotdb/db.py
+++ b/pinotdb/db.py
@@ -267,7 +267,8 @@ def convert_result_if_required(data_types, rows):
     for i, t in enumerate(data_types):
         if t.needs_conversion:
             for row in rows:
-                row[i] = convert_result(t, json.dumps(row[i]))
+                if row[i] is not None:
+                    row[i] = convert_result(t, json.dumps(row[i]))
     return rows
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/python-pinot-dbapi/pinot-dbapi"
 
 [tool.poetry.dependencies]
 python = ">=3.7,<4"
-ciso8601 = "^2.2.0"
+ciso8601 = "^2.1.3"
 httpx = "^0.23.0"
 sqlalchemy = { version = ">=1.4", optional = true }
 requests = "^2.28.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ python = ">=3.7,<4"
 ciso8601 = "^2.1.3"
 httpx = "^0.23.0"
 sqlalchemy = { version = ">=1.4", optional = true }
-requests = "^2.28.1"
+requests = "^2.25.0"
 
 [tool.poetry.extras]
 sqlalchemy = ["sqlalchemy", "requests"]

--- a/tests/test_wrap_example.py
+++ b/tests/test_wrap_example.py
@@ -4,9 +4,12 @@ import os
 import unittest
 
 from contextlib import redirect_stdout, redirect_stderr
+from datetime import datetime
+
 from parameterized import parameterized
 from typing import *
 
+from pinotdb.db import convert_result_if_required, TypeCodeAndValue, Type
 
 _parameterized_test_scripts: List[str] = list()
 skipped_modules: List[str] = [
@@ -44,3 +47,15 @@ class ExampleWrappedTestCase(unittest.TestCase):
                 print("...")
                 std_err_result = std_err.getvalue()
                 assert len(std_err_result) == 0 or std_err_result.find("error") == -1
+
+    def test_null_field_parsing(self) -> None:
+        types = [TypeCodeAndValue(Type.NUMBER, False, False),
+                 TypeCodeAndValue(Type.STRING, False, False),
+                 TypeCodeAndValue(Type.BOOLEAN, False, False),
+                 TypeCodeAndValue(Type.TIMESTAMP, False, True)]
+        rows = [[1, "abc", True, "2022-12-22 01:46:28.0"],
+                [None, None, None, None]]
+        res = convert_result_if_required(types, rows)
+
+        assert res == [[1, "abc", True, datetime(2022, 12, 22, 1, 46, 28)],
+                       [None, None, None, None]]


### PR DESCRIPTION
- Loose dependency requirements for ciso8601 and requests.
- Adding Unit test for null handling