### PR TITLE
JSON type field parsing from string to dict

### DIFF
--- a/tests/integration/test_wrap_example.py
+++ b/tests/integration/test_wrap_example.py
@@ -52,10 +52,12 @@ class ExampleWrappedTestCase(unittest.TestCase):
         types = [TypeCodeAndValue(Type.NUMBER, False, False),
                  TypeCodeAndValue(Type.STRING, False, False),
                  TypeCodeAndValue(Type.BOOLEAN, False, False),
-                 TypeCodeAndValue(Type.TIMESTAMP, False, True)]
-        rows = [[1, "abc", True, "2022-12-22 01:46:28.0"],
-                [None, None, None, None]]
+                 TypeCodeAndValue(Type.TIMESTAMP, False, True),
+                 TypeCodeAndValue(Type.JSON, False, True),
+                 TypeCodeAndValue(Type.JSON, False, True)]
+        rows = [[1, "abc", True, "2022-12-22 01:46:28.0", '{"field1": "value1"}', '[{"field1": "value1"}]'],
+                [None, None, None, None, None, None]]
         res = convert_result_if_required(types, rows)
 
-        assert res == [[1, "abc", True, datetime(2022, 12, 22, 1, 46, 28)],
-                       [None, None, None, None]]
+        assert res == [[1, "abc", True, datetime(2022, 12, 22, 1, 46, 28), {"field1": "value1"}, [{"field1": "value1"}]],
+                       [None, None, None, None, None, None]]


### PR DESCRIPTION
Pinot returns JSON datatype fields as string. This PR parses the string into dict.