### PR TITLE
Fix JSON datatype parsing for empty string

### DIFF
--- a/pinotdb/db.py
+++ b/pinotdb/db.py
@@ -285,7 +285,7 @@ def convert_result(data_type, raw_row):
         return ciso8601.parse_datetime(raw_row)
     elif data_type.code == Type.JSON:
         # Pinot returns JSON as STRING
-        return json.loads(raw_row)
+        return json.loads(raw_row) if raw_row != '' else None
     else:
         return json.dumps(raw_row)
 

--- a/tests/integration/test_wrap_example.py
+++ b/tests/integration/test_wrap_example.py
@@ -54,10 +54,13 @@ class ExampleWrappedTestCase(unittest.TestCase):
                  TypeCodeAndValue(Type.BOOLEAN, False, False),
                  TypeCodeAndValue(Type.TIMESTAMP, False, True),
                  TypeCodeAndValue(Type.JSON, False, True),
+                 TypeCodeAndValue(Type.JSON, False, True),
                  TypeCodeAndValue(Type.JSON, False, True)]
-        rows = [[1, "abc", True, "2022-12-22 01:46:28.0", '{"field1": "value1"}', '[{"field1": "value1"}]'],
-                [None, None, None, None, None, None]]
+        rows = [[1, "abc", True, "2022-12-22 01:46:28.0", '{"field1": "value1"}', '[{"field1": "value1"}]', ''],
+                [None, None, None, None, None, None, None]]
         res = convert_result_if_required(types, rows)
 
-        assert res == [[1, "abc", True, datetime(2022, 12, 22, 1, 46, 28), {"field1": "value1"}, [{"field1": "value1"}]],
-                       [None, None, None, None, None, None]]
+        assert res == [
+            [1, "abc", True, datetime(2022, 12, 22, 1, 46, 28), {"field1": "value1"}, [{"field1": "value1"}], None],
+            [None, None, None, None, None, None, None]
+        ]


### PR DESCRIPTION
When the Pinot server returns an empty string (`''`) for JSON datatype field, `json.loads` will fail to parse it. Hence, returning `None` for such fields.