### PR TITLE
Fix bug where equal sign could not be in value of header

### DIFF
--- a/pinotdb/db.py
+++ b/pinotdb/db.py
@@ -330,7 +330,7 @@ class Cursor:
         extra_headers = {}
         if extra_request_headers:
             for header in extra_request_headers.split(","):
-                k, v = header.split("=")
+                k, v = header.split("=", 1)
                 extra_headers[k] = v
 
         self.session.headers.update(extra_headers)

--- a/tests/unit/test_db.py
+++ b/tests/unit/test_db.py
@@ -331,10 +331,11 @@ class CursorTest(TestCase):
     def test_instantiates_with_extra_headers(self):
         cursor = db.Cursor(
             host='localhost', session=httpx.Client(),
-            extra_request_headers='foo=bar,baz=yo')
+            extra_request_headers='foo=bar,baz=yo,Authorization=Bearer foo=')
 
         self.assertEqual(cursor.session.headers['foo'], 'bar')
         self.assertEqual(cursor.session.headers['baz'], 'yo')
+        self.assertEqual(cursor.session.headers['Authorization'], 'Bearer foo=')
 
     def test_checks_valid_exception_if_not_containing_error_code(self):
         cursor = db.Cursor(host='localhost', session=httpx.Client())


### PR DESCRIPTION
Fix bug in #83

If the value contains an `=` the code would crash. There are scenarios where the key could have an equal sign for example when passing in a bearer token.

This PR splits the header on the first `=` in the headers. This PR also adds a test case to verify that the change works as expected.