### PR TITLE
Added support for providing a timeout option while setting up a connection

### DIFF
--- a/examples/pinot_quickstart_timeout.py
+++ b/examples/pinot_quickstart_timeout.py
@@ -1,0 +1,46 @@
+from pinotdb import connect
+import time
+import pytest
+import httpx
+
+## Start Pinot Quickstart Batch
+## docker run --name pinot-quickstart -p 2123:2123 -p 9000:9000 -p 8000:8000 \
+##    -d apachepinot/pinot:latest QuickStart -type hybrid
+
+def run_pinot_quickstart_timeout_example() -> None:
+
+    #Test 1 : Try without timeout and wait for more than 5 seconds. The query should execute without exceptions.
+
+    conn = connect(host="localhost", port=8000, path="/query/sql", scheme="http")
+    curs = conn.cursor()
+    sql = "SELECT * FROM airlineStats LIMIT 5"
+    print(f"Sending SQL to Pinot: {sql}")
+    time.sleep(5.001)
+    curs.execute(sql)
+
+    #Test 2 : Try with timeout=None and wait for more than 5 seconds. The query should execute without exceptions.
+
+    conn = connect(host="localhost", port=8000, path="/query/sql", scheme="http", timeout=None)
+    curs = conn.cursor()
+    sql = "SELECT * FROM airlineStats LIMIT 5"
+    print(f"Sending SQL to Pinot: {sql}")
+    time.sleep(5.001)
+    curs.execute(sql)
+
+    #Test 3 : Try with a timeout less than the sleep time. The query should raise an exception.
+
+    conn = connect(host="localhost", port=8000, path="/query/sql", scheme="http", timeout=0.001)
+    curs = conn.cursor()
+    sql = "SELECT * FROM airlineStats LIMIT 5"
+    print(f"Sending SQL to Pinot: {sql}")
+    with pytest.raises(httpx.ReadTimeout):
+        time.sleep(0.002)
+        curs.execute(sql)
+
+
+def run_main():
+    run_pinot_quickstart_timeout_example()
+
+
+if __name__ == '__main__':
+    run_main()

--- a/examples/pinot_quickstart_timeout.py
+++ b/examples/pinot_quickstart_timeout.py
@@ -9,33 +9,33 @@ import httpx
 
 def run_pinot_quickstart_timeout_example() -> None:
 
-    #Test 1 : Try without timeout and wait for more than 5 seconds. The query should execute without exceptions.
+    #Test 1 : Try without timeout. The request should succeed.
 
     conn = connect(host="localhost", port=8000, path="/query/sql", scheme="http")
     curs = conn.cursor()
     sql = "SELECT * FROM airlineStats LIMIT 5"
     print(f"Sending SQL to Pinot: {sql}")
-    time.sleep(5.001)
     curs.execute(sql)
+    conn.close()
 
-    #Test 2 : Try with timeout=None and wait for more than 5 seconds. The query should execute without exceptions.
+    #Test 2 : Try with timeout=None. The request should succeed.
 
     conn = connect(host="localhost", port=8000, path="/query/sql", scheme="http", timeout=None)
     curs = conn.cursor()
-    sql = "SELECT * FROM airlineStats LIMIT 5"
+    sql = "SELECT count(*) FROM airlineStats LIMIT 5"
     print(f"Sending SQL to Pinot: {sql}")
-    time.sleep(5.001)
     curs.execute(sql)
+    conn.close()
 
-    #Test 3 : Try with a timeout less than the sleep time. The query should raise an exception.
+    #Test 3 : Try with a really small timeout. The query should raise an exception.
 
     conn = connect(host="localhost", port=8000, path="/query/sql", scheme="http", timeout=0.001)
     curs = conn.cursor()
-    sql = "SELECT * FROM airlineStats LIMIT 5"
+    sql = "SELECT AirlineID, sum(Cancelled) FROM airlineStats WHERE Year > 2010 GROUP BY AirlineID LIMIT 5"
     print(f"Sending SQL to Pinot: {sql}")
     with pytest.raises(httpx.ReadTimeout):
-        time.sleep(0.002)
         curs.execute(sql)
+    conn.close()
 
 
 def run_main():

--- a/pinotdb/db.py
+++ b/pinotdb/db.py
@@ -147,6 +147,7 @@ class Connection:
         if self.session:
             self.verify_session()
             self.is_session_external = True
+        self.timeout = kwargs.get('timeout', 'None')
 
     def verify_session(self):
         if self.session:
@@ -179,7 +180,8 @@ class Connection:
         """Return a new Cursor Object using the connection."""
         if not self.session or self.session.is_closed:
             self.session = httpx.Client(
-                verify=self._kwargs.get('verify_ssl'))
+                verify=self._kwargs.get('verify_ssl'),
+                timeout=self._kwargs.get('timeout'))
 
         self._kwargs['session'] = self.session
         cursor = Cursor(*self._args, **self._kwargs)

--- a/pinotdb/db.py
+++ b/pinotdb/db.py
@@ -147,7 +147,6 @@ class Connection:
         if self.session:
             self.verify_session()
             self.is_session_external = True
-        self.timeout = kwargs.get('timeout', 'None')
 
     def verify_session(self):
         if self.session:


### PR DESCRIPTION
Added support for adding a timeout option (in seconds) while setting up a connection. If no timeout is provided, the default behaviour is to have no timeouts.