### PR TITLE
Allow passing database for pinot queries

### DIFF
--- a/examples/pinot_async.py
+++ b/examples/pinot_async.py
@@ -7,7 +7,8 @@ from pinotdb import connect_async
 
 async def run_pinot_async_example():
     async with connect_async(host='localhost', port=8000, path='/query/sql',
-                             scheme='http', verify_ssl=False, timeout=10.0) as conn:
+                             scheme='http', verify_ssl=False, timeout=10.0,
+                             extra_request_headers="Database=default") as conn:
         curs = await conn.execute("""
             SELECT count(*)
               FROM baseballStats
@@ -20,7 +21,7 @@ async def run_pinot_async_example():
     session = httpx.AsyncClient(verify=False)
     conn = connect_async(
         host='localhost', port=8000, path='/query/sql', scheme='http',
-        verify_ssl=False, session=session)
+        verify_ssl=False, session=session, extra_request_headers="Database=default")
 
     # launch 10 requests in parallel spanning a limit/offset range
     reqs = []

--- a/examples/pinot_live.py
+++ b/examples/pinot_live.py
@@ -8,7 +8,8 @@ from sqlalchemy.orm import sessionmaker
 
 def run_pinot_live_example() -> None:
     # Query pinot.live with pinotdb connect
-    conn = connect(host="pinot-broker.pinot.live", port=443, path="/query/sql", scheme="https")
+    conn = connect(host="pinot-broker.pinot.live", port=443, path="/query/sql", scheme="https",
+                   extra_request_headers="Database=default")
     curs = conn.cursor()
     sql = "SELECT * FROM airlineStats LIMIT 5"
     print(f"Sending SQL to Pinot: {sql}")
@@ -21,7 +22,7 @@ def run_pinot_live_example() -> None:
         "pinot+https://pinot-broker.pinot.live:443/query/sql?controller=https://pinot-controller.pinot.live/"
     )  # uses HTTP by default :(
 
-    airlineStats = Table("airlineStats", MetaData(bind=engine), autoload=True)
+    airlineStats = Table("airlineStats", MetaData(bind=engine), autoload=True, schema="default")
     print(f"\nSending Count(*) SQL to Pinot")
     query=select([func.count("*")], from_obj=airlineStats)
     print(engine.execute(query).scalar())

--- a/examples/pinot_quickstart_auth_zk.py
+++ b/examples/pinot_quickstart_auth_zk.py
@@ -20,6 +20,7 @@ def run_pinot_quickstart_batch_example() -> None:
         scheme="http",
         username="admin",
         password="verysecret",
+        extra_request_headers="Database=default",
     )
     curs = conn.cursor()
     tables = [
@@ -65,7 +66,7 @@ def run_pinot_quickstart_batch_sqlalchemy_example() -> None:
     # engine = create_engine('pinot+http://localhost:8000/query/sql?controller=http://localhost:9000/')
     # engine = create_engine('pinot+https://localhost:8000/query/sql?controller=http://localhost:9000/')
 
-    baseballStats = Table("baseballStats", MetaData(bind=engine), autoload=True)
+    baseballStats = Table("baseballStats", MetaData(bind=engine), autoload=True, schema="default")
     print(f"\nSending Count(*) SQL to Pinot")
     query = select([func.count("*")], from_obj=baseballStats)
     print(engine.execute(query).scalar())

--- a/examples/pinot_quickstart_batch.py
+++ b/examples/pinot_quickstart_batch.py
@@ -12,7 +12,8 @@ from sqlalchemy.orm import sessionmaker
 
 
 def run_pinot_quickstart_batch_example() -> None:
-    conn = connect(host="localhost", port=8000, path="/query/sql", scheme="http")
+    conn = connect(host="localhost", port=8000, path="/query/sql", scheme="http",
+                   extra_request_headers="Database=default")
     curs = conn.cursor()
 
     tables = [
@@ -52,7 +53,7 @@ def run_pinot_quickstart_batch_sqlalchemy_example() -> None:
     # engine = create_engine('pinot+http://localhost:8000/query/sql?controller=http://localhost:9000/')
     # engine = create_engine('pinot+https://localhost:8000/query/sql?controller=http://localhost:9000/')
 
-    baseballStats = Table("baseballStats", MetaData(bind=engine), autoload=True)
+    baseballStats = Table("baseballStats", MetaData(bind=engine), autoload=True, schema="default")
     print(f"\nSending Count(*) SQL to Pinot")
     query = select([func.count("*")], from_obj=baseballStats)
     print(engine.execute(query).scalar())

--- a/examples/pinot_quickstart_hybrid.py
+++ b/examples/pinot_quickstart_hybrid.py
@@ -11,7 +11,8 @@ from sqlalchemy.orm import sessionmaker
 ##    -d apachepinot/pinot:latest QuickStart -type hybrid
 
 def run_pinot_quickstart_hybrid_example() -> None:
-    conn = connect(host="localhost", port=8000, path="/query/sql", scheme="http")
+    conn = connect(host="localhost", port=8000, path="/query/sql", scheme="http",
+                   extra_request_headers="Database=default")
     curs = conn.cursor()
     sql = "SELECT * FROM airlineStats LIMIT 5"
     print(f"Sending SQL to Pinot: {sql}")
@@ -53,7 +54,7 @@ def run_pinot_quickstart_hybrid_sqlalchemy_example() -> None:
     # engine = create_engine('pinot+http://localhost:8000/query/sql?controller=http://localhost:9000/')
     # engine = create_engine('pinot+https://localhost:8000/query/sql?controller=http://localhost:9000/')
 
-    airlineStats = Table("airlineStats", MetaData(bind=engine), autoload=True)
+    airlineStats = Table("airlineStats", MetaData(bind=engine), autoload=True, schema="default")
     print(f"\nSending Count(*) SQL to Pinot")
     query=select([func.count("*")], from_obj=airlineStats)
     print(engine.execute(query).scalar())

--- a/examples/pinot_quickstart_json_batch.py
+++ b/examples/pinot_quickstart_json_batch.py
@@ -13,7 +13,8 @@ from sqlalchemy.orm import sessionmaker
 
 
 def run_quickstart_json_batch_example() -> None:
-    conn = connect(host="localhost", port=8000, path="/query/sql", scheme="http")
+    conn = connect(host="localhost", port=8000, path="/query/sql", scheme="http",
+                   extra_request_headers="Database=default")
     curs = conn.cursor()
     sql = "SELECT * FROM githubEvents LIMIT 5"
     print(f"Sending SQL to Pinot: {sql}")
@@ -43,7 +44,7 @@ def run_quickstart_json_batch_sqlalchemy_example() -> None:
     # engine = create_engine('pinot+http://localhost:8000/query/sql?controller=http://localhost:9000/')
     # engine = create_engine('pinot+https://localhost:8000/query/sql?controller=http://localhost:9000/')
 
-    githubEvents = Table("githubEvents", MetaData(bind=engine), autoload=True)
+    githubEvents = Table("githubEvents", MetaData(bind=engine), autoload=True, schema="default")
     print(f"\nSending Count(*) SQL to Pinot\nResults:")
     query=select([func.count("*")], from_obj=githubEvents)
     print(engine.execute(query).scalar())

--- a/examples/pinot_quickstart_multi_stage.py
+++ b/examples/pinot_quickstart_multi_stage.py
@@ -11,7 +11,8 @@ from sqlalchemy.orm import sessionmaker
 ##    -d apachepinot/pinot:latest QuickStart -type MULTI_STAGE
 
 def run_pinot_quickstart_multi_stage_example() -> None:
-    conn = connect(host="localhost", port=8000, path="/query/sql", scheme="http", use_multistage_engine=True)
+    conn = connect(host="localhost", port=8000, path="/query/sql", scheme="http", use_multistage_engine=True,
+                   extra_request_headers="Database=default")
     curs = conn.cursor()
 
     sql = "SELECT a.playerID, a.runs, a.yearID, b.runs, b.yearID FROM baseballStats_OFFLINE AS a JOIN baseballStats_OFFLINE AS b ON a.playerID = b.playerID WHERE a.runs > 160 AND b.runs < 2 LIMIT 10"

--- a/examples/pinot_quickstart_timeout.py
+++ b/examples/pinot_quickstart_timeout.py
@@ -11,7 +11,8 @@ def run_pinot_quickstart_timeout_example() -> None:
 
     #Test 1 : Try without timeout. The request should succeed.
 
-    conn = connect(host="localhost", port=8000, path="/query/sql", scheme="http")
+    conn = connect(host="localhost", port=8000, path="/query/sql", scheme="http",
+                   extra_request_headers="Database=default")
     curs = conn.cursor()
     sql = "SELECT * FROM airlineStats LIMIT 5"
     print(f"Sending SQL to Pinot: {sql}")
@@ -20,7 +21,8 @@ def run_pinot_quickstart_timeout_example() -> None:
 
     #Test 2 : Try with timeout=None. The request should succeed.
 
-    conn = connect(host="localhost", port=8000, path="/query/sql", scheme="http", timeout=None)
+    conn = connect(host="localhost", port=8000, path="/query/sql", scheme="http", timeout=None,
+                   extra_request_headers="Database=default")
     curs = conn.cursor()
     sql = "SELECT count(*) FROM airlineStats LIMIT 5"
     print(f"Sending SQL to Pinot: {sql}")
@@ -29,7 +31,8 @@ def run_pinot_quickstart_timeout_example() -> None:
 
     #Test 3 : Try with a really small timeout. The query should raise an exception.
 
-    conn = connect(host="localhost", port=8000, path="/query/sql", scheme="http", timeout=0.001)
+    conn = connect(host="localhost", port=8000, path="/query/sql", scheme="http", timeout=0.001,
+                   extra_request_headers="Database=default")
     curs = conn.cursor()
     sql = "SELECT AirlineID, sum(Cancelled) FROM airlineStats WHERE Year > 2010 GROUP BY AirlineID LIMIT 5"
     print(f"Sending SQL to Pinot: {sql}")

--- a/pinotdb/db.py
+++ b/pinotdb/db.py
@@ -162,7 +162,7 @@ class Connection:
             except exceptions.Error:
                 pass  # already closed
         # if we're managing the httpx session, attempt to close it
-        if not self.is_session_external:
+        if not self.is_session_external and self.session:
             self.session.close()
 
     @check_closed
@@ -334,8 +334,8 @@ class Cursor:
             for header in extra_request_headers.split(","):
                 k, v = header.split("=", 1)
                 extra_headers[k] = v
-
-        extra_headers['database'] = kwargs['database']
+        if 'database' in kwargs:
+            extra_headers['database'] = kwargs['database']
         self.session.headers.update(extra_headers)
 
     @check_closed
@@ -383,12 +383,6 @@ class Cursor:
                 queryOptions += ";useMultistageEngine=true"
             else:
                 queryOptions = "useMultistageEngine=true"
-        database = self.session.headers['database']
-        if database:
-            if queryOptions:
-                queryOptions += f";database={database}"
-            else:
-                queryOptions = f"database={database}"
         if queryOptions:
             return {"sql": query, "queryOptions": queryOptions}
         else:

--- a/pinotdb/db.py
+++ b/pinotdb/db.py
@@ -335,6 +335,7 @@ class Cursor:
                 k, v = header.split("=", 1)
                 extra_headers[k] = v
 
+        extra_headers['database'] = kwargs['database']
         self.session.headers.update(extra_headers)
 
     @check_closed
@@ -382,6 +383,12 @@ class Cursor:
                 queryOptions += ";useMultistageEngine=true"
             else:
                 queryOptions = "useMultistageEngine=true"
+        database = self.session.headers['database']
+        if database:
+            if queryOptions:
+                queryOptions += f";database={database}"
+            else:
+                queryOptions = f"database={database}"
         if queryOptions:
             return {"sql": query, "queryOptions": queryOptions}
         else:

--- a/pinotdb/sqlalchemy.py
+++ b/pinotdb/sqlalchemy.py
@@ -230,13 +230,20 @@ class PinotDialect(default.DefaultDialect):
         return result
 
     def get_schema_names(self, connection, **kwargs):
-        return [self._database]
+        if self._database:
+            return [self._database]
+        else:
+            return ['default']
 
     def has_table(self, connection, table_name, schema=None):
         return table_name in self.get_table_names(connection, schema)
 
     def get_table_names(self, connection, schema=None, **kwargs):
-        return list(map(extract_table_name, self.get_metadata_from_controller("/tables")["tables"]))
+        resp = self.get_metadata_from_controller("/tables")
+        if 'tables' in resp:
+            return list(map(extract_table_name, resp["tables"]))
+        else:
+            return []
 
     def get_view_names(self, connection, schema=None, **kwargs):
         return []

--- a/tests/unit/test_sqlalchemy.py
+++ b/tests/unit/test_sqlalchemy.py
@@ -103,13 +103,12 @@ class PinotDialectTest(PinotTestCase):
         with self.assertRaises(exceptions.DatabaseError):
             self.dialect.get_metadata_from_controller('some-path')
 
-    @responses.activate
     def test_gets_schema_names(self):
-        url = f'{self.dialect._controller}/databases'
-        responses.get(url, json=['default', 'foo', 'bar'])
         names = self.dialect.get_schema_names('some connection')
-
-        self.assertEqual(names, ['default', 'foo', 'bar'])
+        self.assertEqual(names, ['default'])
+        self.dialect._database = 'foo'
+        names = self.dialect.get_schema_names('some connection')
+        self.assertEqual(names, ['foo'])
 
     @responses.activate
     def test_gets_table_names_from_controller(self):

--- a/tests/unit/test_sqlalchemy.py
+++ b/tests/unit/test_sqlalchemy.py
@@ -103,10 +103,13 @@ class PinotDialectTest(PinotTestCase):
         with self.assertRaises(exceptions.DatabaseError):
             self.dialect.get_metadata_from_controller('some-path')
 
+    @responses.activate
     def test_gets_schema_names(self):
+        url = f'{self.dialect._controller}/databases'
+        responses.get(url, json=['default', 'foo', 'bar'])
         names = self.dialect.get_schema_names('some connection')
 
-        self.assertEqual(names, ['default'])
+        self.assertEqual(names, ['default', 'foo', 'bar'])
 
     @responses.activate
     def test_gets_table_names_from_controller(self):


### PR DESCRIPTION
Pass `database=dbName` argument as part of the connection string to query tables of a specific database.
Each connection can query only 1 database.