### PR TITLE
Add timeout for async connection

### DIFF
--- a/pinotdb/db.py
+++ b/pinotdb/db.py
@@ -211,7 +211,8 @@ class AsyncConnection(Connection):
         """Return a new Cursor Object using the connection."""
         if not self.session or self.session.is_closed:
             self.session = httpx.AsyncClient(
-                verify=self._kwargs.get('verify_ssl'))
+                verify=self._kwargs.get('verify_ssl'),
+                timeout=self._kwargs.get('timeout'))
 
         self._kwargs['session'] = self.session
         cursor = AsyncCursor(*self._args, **self._kwargs)


### PR DESCRIPTION
Right now only the connect() supports timeout, not the connect_async version