### PR TITLE
Allow pinot table aliases

### DIFF
--- a/pinotdb/sqlalchemy.py
+++ b/pinotdb/sqlalchemy.py
@@ -21,9 +21,6 @@ class PinotCompiler(compiler.SQLCompiler):
         return super().visit_select(select, **kwargs)
 
     def visit_column(self, column, result_map=None, **kwargs):
-        # Pinot does not support table aliases
-        if column.table is not None:
-            column.table.named_with_column = False
         result_map = result_map or kwargs.pop("add_to_result_map", None)
         # This is a hack to modify the original column, but how do I clone it ?
         column.is_literal = True

--- a/tests/unit/test_sqlalchemy.py
+++ b/tests/unit/test_sqlalchemy.py
@@ -344,7 +344,7 @@ class PinotCompilerTest(PinotTestCase):
 
         self.assertEqual(
             str(compiler),
-            'SELECT some_column \nFROM some_table',
+            'SELECT some_table.some_column \nFROM some_table',
         )
 
 


### PR DESCRIPTION
My team has been using this pinot driver with the SQL Alchemy ORM and ran into a bit of an issue with missing table names in `JOIN` clauses during execution.

When printing the generated query things look good:
```SQL
SELECT table1.a, table1.b, table2.c
FROM table1
JOIN table2 ON table1.a = table2.a
```

but when executing the query the table names are dropped from all the columns:
```SQL
SELECT a, b, c
FROM table1
JOIN table2 ON a = a
```

and we end up with a query that won't run because the `ON a = a` portion of the `JOIN` clause is ambiguous.

I checked the commit history for the lines I deleted and didn't learn much about their origin. Is it possible Pinot has advanced in the years since they were originally written? We've moved our code over to our fork of the driver and haven't noticed any side effects yet.

If this solution is unacceptable please let me know what I need to change.