### PR TITLE
Way to set query params at connection level

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,15 @@ places = Table('places', MetaData(bind=engine), autoload=True)
 print(select([func.count('*')], from_obj=places).scalar())
 ```
 
+To configure query parameters (such as `timeoutMs=10000`) at the engine level
+you may pass them while creating the engine. For example:
+
+```python
+engine = create_engine(
+        "pinot://localhost:8000/query/sql?controller=http://localhost:9000/",
+        connect_args={"query_options": "useMultistageEngine=true;timeoutMs=10000"})
+```
+
 #### Pass the Pinot database context
 
 > [!IMPORTANT]

--- a/examples/pinot_live.py
+++ b/examples/pinot_live.py
@@ -19,7 +19,8 @@ def run_pinot_live_example() -> None:
 
     # Query pinot.live with sqlalchemy
     engine = create_engine(
-        "pinot+https://pinot-broker.pinot.live:443/query/sql?controller=https://pinot-controller.pinot.live/"
+        "pinot+https://pinot-broker.pinot.live:443/query/sql?controller=https://pinot-controller.pinot.live/",
+        connect_args={"query_options": "timeoutMs=10000"}
     )  # uses HTTP by default :(
 
     airlineStats = Table("airlineStats", MetaData(bind=engine), autoload=True, schema="default")

--- a/examples/pinot_quickstart_hybrid.py
+++ b/examples/pinot_quickstart_hybrid.py
@@ -49,7 +49,8 @@ def run_pinot_quickstart_hybrid_sqlalchemy_example() -> None:
     registry.register("pinot", "pinotdb.sqlalchemy", "PinotDialect")
 
     engine = create_engine(
-        "pinot://localhost:8000/query/sql?controller=http://localhost:9000/"
+        "pinot://localhost:8000/query/sql?controller=http://localhost:9000/",
+        connect_args={"query_options": "timeoutMs=10000"}
     )  # uses HTTP by default :(
     # engine = create_engine('pinot+http://localhost:8000/query/sql?controller=http://localhost:9000/')
     # engine = create_engine('pinot+https://localhost:8000/query/sql?controller=http://localhost:9000/')


### PR DESCRIPTION
This can be leveraged by clients such as superset to apply query params at connection level to avoid passing it for every query.

Example of database connection creation in Superset:

<img width="500" alt="image" src="https://github.com/python-pinot-dbapi/pinot-dbapi/assets/25409127/8301ba7b-2226-4c3b-913e-c45fce610c81">

