### PR TITLE
Add raw query response to cursor class

### DIFF
--- a/pinotdb/db.py
+++ b/pinotdb/db.py
@@ -396,8 +396,15 @@ class Cursor:
     def normalize_query_response(self, input_query, query_response):
         try:
             payload = query_response.json()
-            self.raw_query_response = payload
+            self.raw_query_response = {
+                "response" : payload, 
+                "response_status" : query_response.status_code
+                }
         except Exception as e:
+            self.raw_query_response = {
+                "response" : query_response.text, 
+                "response_status" : query_response.status_code
+                }
             raise exceptions.DatabaseError(
                 f"Error when querying {input_query} from {self.url}, "
                 f"raw response is:\n{query_response.text}"

--- a/pinotdb/db.py
+++ b/pinotdb/db.py
@@ -314,6 +314,7 @@ class Cursor:
         self.schema = None
         self.rowcount = -1
         self._results = None
+        self.raw_query_response = None
         self.timeUsedMs = -1
         self._debug = debug
         self._preserve_types = preserve_types
@@ -395,6 +396,7 @@ class Cursor:
     def normalize_query_response(self, input_query, query_response):
         try:
             payload = query_response.json()
+            self.raw_query_response = payload
         except Exception as e:
             raise exceptions.DatabaseError(
                 f"Error when querying {input_query} from {self.url}, "

--- a/pinotdb/db.py
+++ b/pinotdb/db.py
@@ -397,13 +397,13 @@ class Cursor:
         try:
             payload = query_response.json()
             self.raw_query_response = {
-                "response" : payload, 
-                "response_status" : query_response.status_code
+                    "response" : payload, 
+                    "status_code" : query_response.status_code
                 }
         except Exception as e:
             self.raw_query_response = {
-                "response" : query_response.text, 
-                "response_status" : query_response.status_code
+                    "response" : query_response.text, 
+                    "status_code" : query_response.status_code
                 }
             raise exceptions.DatabaseError(
                 f"Error when querying {input_query} from {self.url}, "

--- a/tests/unit/test_db.py
+++ b/tests/unit/test_db.py
@@ -678,6 +678,120 @@ class CursorTest(TestCase):
         cursor.setoutputsizes(123)
 
         # All good, nothing happened
+    
+    def test_checks_raw_query_response_with_single_stage_and_status_code_200(self):
+        cursor = self.create_cursor(
+                    {
+                        'dataSchema': {
+                            'columnNames': ['age'],
+                            'columnDataTypes': ['INT'],
+                        },
+                        'rows': [[1], [2], [3]],
+                    },
+                    status_code=200,
+                    extra_payload={'numGroupsLimitReached': True},
+                    use_multistage_engine=False
+                )
+        cursor.execute('some statement')
+        raw_query_response = {
+            'response': {
+                'numServersResponded': 1,
+                'numServersQueried': 1,
+                'resultTable': {
+                    'dataSchema': {'columnNames': ['age'], 'columnDataTypes': ['INT']},
+                    'rows': [[1], [2], [3]],
+                },
+                'numGroupsLimitReached': True,
+            },
+            'status_code': 200,
+        }
+        self.assertEqual(cursor.raw_query_response, raw_query_response)
+
+    def test_checks_raw_query_response_with_multi_stage_and_status_code_200(self):
+        cursor = self.create_cursor(
+                    {
+                        'dataSchema': {
+                            'columnNames': ['age'],
+                            'columnDataTypes': ['INT'],
+                        },
+                        'rows': [[1], [2], [3]],
+                    },
+                    status_code=200,
+                    extra_payload={'numGroupsLimitReached': True},
+                    use_multistage_engine=True
+                )
+        cursor.execute('some statement')
+        raw_query_response = {
+            'response': {
+                'numServersResponded': 1,
+                'numServersQueried': 1,
+                'resultTable': {
+                    'dataSchema': {'columnNames': ['age'], 'columnDataTypes': ['INT']},
+                    'rows': [[1], [2], [3]],
+                },
+                'numGroupsLimitReached': True,
+            },
+            'status_code': 200,
+        }
+        self.assertEqual(cursor.raw_query_response, raw_query_response)
+
+    def test_checks_raw_query_response_with_single_stage_and_status_code_400(self):
+        cursor = self.create_cursor(
+            {
+                'dataSchema': {
+                    'columnNames': ['age'],
+                    'columnDataTypes': ['INT'],
+                },
+                'rows': [[1], [2], [3]],
+            },
+            status_code=400,
+            extra_payload={'exceptions': ['something', 'wrong']},
+            use_multistage_engine=False
+        )
+        with self.assertRaises(exceptions.ProgrammingError):
+            cursor.execute('some statement')
+        raw_query_response = {
+            'response': {
+                'numServersResponded': 1,
+                'numServersQueried': 1,
+                'resultTable': {
+                    'dataSchema': {'columnNames': ['age'], 'columnDataTypes': ['INT']},
+                    'rows': [[1], [2], [3]],
+                },
+                'exceptions': ['something', 'wrong'],
+            },
+            'status_code': 400,
+        }
+        self.assertEqual(cursor.raw_query_response, raw_query_response)
+
+    def test_checks_raw_query_response_with_multi_stage_and_status_code_400(self):
+        cursor = self.create_cursor(
+            {
+                'dataSchema': {
+                    'columnNames': ['age'],
+                    'columnDataTypes': ['INT'],
+                },
+                'rows': [[1], [2], [3]],
+            },
+            status_code=400,
+            extra_payload={'exceptions': ['something', 'wrong']},
+            use_multistage_engine=True
+        )
+        with self.assertRaises(exceptions.ProgrammingError):
+            cursor.execute('some statement')
+        raw_query_response = {
+            'response': {
+                'numServersResponded': 1,
+                'numServersQueried': 1,
+                'resultTable': {
+                    'dataSchema': {'columnNames': ['age'], 'columnDataTypes': ['INT']},
+                    'rows': [[1], [2], [3]],
+                },
+                'exceptions': ['something', 'wrong'],
+            },
+            'status_code': 400,
+        }
+        self.assertEqual(cursor.raw_query_response, raw_query_response)
 
 
 class AsyncCursorTest(IsolatedAsyncioTestCase):


### PR DESCRIPTION
As of now with this client, we do not have access to rich stats returned by the Pinot API as mentioned in https://github.com/python-pinot-dbapi/pinot-dbapi/issues/88

This PR will store the raw query response json returned by Pinot API. I have stored the raw json directly instead of parsing each statistic into a separate variable. This is to prevent any side effects due to future breaking changes in Pinot API.