### PR TITLE
Fix TypeError when timeout is provided in connection string

### DIFF
--- a/pinotdb/db.py
+++ b/pinotdb/db.py
@@ -181,7 +181,7 @@ class Connection:
         if not self.session or self.session.is_closed:
             self.session = httpx.Client(
                 verify=self._kwargs.get('verify_ssl'),
-                timeout=int(self._kwargs.get('timeout')) if self._kwargs.get('timeout') else None)
+                timeout=float(self._kwargs.get('timeout')) if self._kwargs.get('timeout') else None)
 
         self._kwargs['session'] = self.session
         cursor = Cursor(*self._args, **self._kwargs)
@@ -213,7 +213,7 @@ class AsyncConnection(Connection):
         if not self.session or self.session.is_closed:
             self.session = httpx.AsyncClient(
                 verify=self._kwargs.get('verify_ssl'),
-                timeout=int(self._kwargs.get('timeout')) if self._kwargs.get('timeout') else None)
+                timeout=float(self._kwargs.get('timeout')) if self._kwargs.get('timeout') else None)
 
         self._kwargs['session'] = self.session
         cursor = AsyncCursor(*self._args, **self._kwargs)
@@ -286,7 +286,7 @@ class Cursor:
         # TODO: Remove this unused parameter when we can afford to break the
         #  interface (e.g. new minor version).
         verify_ssl=True,
-        timeout=10,
+        timeout=10.0,
         extra_request_headers="",
         debug=False,
         preserve_types=False,

--- a/pinotdb/db.py
+++ b/pinotdb/db.py
@@ -181,7 +181,7 @@ class Connection:
         if not self.session or self.session.is_closed:
             self.session = httpx.Client(
                 verify=self._kwargs.get('verify_ssl'),
-                timeout=self._kwargs.get('timeout'))
+                timeout=int(self._kwargs.get('timeout')) if self._kwargs.get('timeout') else None)
 
         self._kwargs['session'] = self.session
         cursor = Cursor(*self._args, **self._kwargs)
@@ -213,7 +213,7 @@ class AsyncConnection(Connection):
         if not self.session or self.session.is_closed:
             self.session = httpx.AsyncClient(
                 verify=self._kwargs.get('verify_ssl'),
-                timeout=self._kwargs.get('timeout'))
+                timeout=int(self._kwargs.get('timeout')) if self._kwargs.get('timeout') else None)
 
         self._kwargs['session'] = self.session
         cursor = AsyncCursor(*self._args, **self._kwargs)

--- a/pinotdb/sqlalchemy.py
+++ b/pinotdb/sqlalchemy.py
@@ -182,7 +182,7 @@ class PinotDialect(default.DefaultDialect):
             kwargs["database"] = self._database = kwargs.pop("database")
         kwargs["debug"] = self._debug = bool(kwargs.get("debug", False))
         kwargs["verify_ssl"] = self._verify_ssl = (str(kwargs.get("verify_ssl", "true")).lower() in ['true'])
-        kwargs["timeout"] = self._timeout = int(kwargs.get('timeout')) if kwargs.get('timeout') else None
+        kwargs["timeout"] = self._timeout = float(kwargs.get('timeout')) if kwargs.get('timeout') else None
         logger.info(
             "Updated pinot dialect args from %s: %s and %s",
             dict(map(lambda kv: (kv[0], mask_value(kv[0], kv[1], ['password'])), kwargs.items())),
@@ -209,7 +209,7 @@ class PinotDialect(default.DefaultDialect):
             "username": url.username,
             "password": url.password,
             "verify_ssl": self._verify_ssl or True,
-            "timeout": int(self._timeout) if self._timeout else 10.0,
+            "timeout": float(self._timeout) if self._timeout else 10.0,
         }
         if self.engine_type == "multi_stage":
             kwargs.update({"use_multistage_engine": True})

--- a/pinotdb/sqlalchemy.py
+++ b/pinotdb/sqlalchemy.py
@@ -182,7 +182,7 @@ class PinotDialect(default.DefaultDialect):
             kwargs["database"] = self._database = kwargs.pop("database")
         kwargs["debug"] = self._debug = bool(kwargs.get("debug", False))
         kwargs["verify_ssl"] = self._verify_ssl = (str(kwargs.get("verify_ssl", "true")).lower() in ['true'])
-        kwargs["timeout"] = self._timeout = kwargs.get("timeout", None)
+        kwargs["timeout"] = self._timeout = int(kwargs.get('timeout')) if kwargs.get('timeout') else None
         logger.info(
             "Updated pinot dialect args from %s: %s and %s",
             dict(map(lambda kv: (kv[0], mask_value(kv[0], kv[1], ['password'])), kwargs.items())),
@@ -209,7 +209,7 @@ class PinotDialect(default.DefaultDialect):
             "username": url.username,
             "password": url.password,
             "verify_ssl": self._verify_ssl or True,
-            "timeout": self._timeout or 10.0,
+            "timeout": int(self._timeout) if self._timeout else 10.0,
         }
         if self.engine_type == "multi_stage":
             kwargs.update({"use_multistage_engine": True})

--- a/tests/unit/test_db.py
+++ b/tests/unit/test_db.py
@@ -41,6 +41,17 @@ class ConnectionTest(TestCase):
         connection.verify_session()
         # All good, no errors.
 
+    def test_verifies_timeout_kwargs(self):
+        connection = db.Connection(host='localhost', timeout=100)
+        cursor = connection.cursor()
+
+        self.assertDictEqual(
+            connection.session.timeout.as_dict(), 
+            {'connect': 100.0, 'read': 100.0, 'write': 100.0, 'pool': 100.0}
+            )
+        
+        
+
     def test_fails_to_verify_session_if_unexpected_type(self):
         connection = db.Connection()
         connection.session = object()

--- a/tests/unit/test_sqlalchemy.py
+++ b/tests/unit/test_sqlalchemy.py
@@ -59,6 +59,26 @@ class PinotDialectTest(PinotTestCase):
             'timeout': 10.0,
         })
 
+    def test_checks_timeout_in_query_params(self):
+        url = make_url(
+            'pinot://localhost:8000/query/sql?controller='
+            'http://localhost:9000/&&verify_ssl=True&&timeout=100')
+
+        cargs, cparams = self.dialect.create_connect_args(url)
+
+        self.assertEqual(cargs, [])
+        self.assertEqual(cparams, {
+            'debug': False,
+            'scheme': 'http',
+            'host': 'localhost',
+            'port': 8000,
+            'path': 'query/sql',
+            'username': None,
+            'password': None,
+            'verify_ssl': True,
+            'timeout': 100,
+        })
+
     def test_creates_connection_args_without_query(self):
         url = make_url('pinot://localhost:8000/query/sql')
 


### PR DESCRIPTION
When timeout is provided as a query parameter in connection string, like the following 
````
'pinot://localhost:8000/query/sql?controller='
       'http://localhost:9000/&&verify_ssl=True&&timeout=100'
````
we get TypeError : 'str' can't be converted to int

We need to convert timeout from string to int and then use it. This is fixed in this PR.