### PR TITLE
Fix: Upgrade h11 and httpx, and bump Python requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,11 +9,12 @@ packages = [{include = "pinotdb"}]
 homepage = "https://github.com/python-pinot-dbapi/pinot-dbapi"
 
 [tool.poetry.dependencies]
-python = ">=3.7,<4"
+python = ">=3.8,<4"
 ciso8601 = "^2.1.3"
-httpx = ">=0.23.0,<0.28.0"
+httpx = "0.28.1"
 sqlalchemy = {version = ">=1.4,<2", optional = true}
 requests = "^2.25.0"
+h11 = "0.16.0"
 
 [tool.poetry.extras]
 sqlalchemy = ["sqlalchemy", "requests"]


### PR DESCRIPTION
Fix:  https://github.com/python-pinot-dbapi/pinot-dbapi/issues/108

## Summary:

Upgrades h11 to 0.16.0 (addresses CVE-2025-43859).
Upgrades httpx to 0.28.1 (required by h11 0.16.0).
Bumps minimum Python version to >=3.8,<4 (required by httpx 0.28.1).

## Details:

The previous version of h11 (0.14.0) is affected by a security vulnerability ([CVE-2025-43859](https://probable-garbanzo-97w694xx7wf7xqw.github.dev/)).
httpx 0.28.1 is required for compatibility with h11 0.16.0, but it requires Python 3.8+.
The [pyproject.toml](https://probable-garbanzo-97w694xx7wf7xqw.github.dev/) has been updated accordingly.

## Impact:

Users must use Python 3.8 or newer.
This resolves a critical security issue and ensures compatibility with the latest dependencies.