### PR TITLE
Fix TIMESTAMP columns compiling to NUMERIC in PinotTypeCompiler

### DIFF
--- a/pinotdb/sqlalchemy.py
+++ b/pinotdb/sqlalchemy.py
@@ -78,7 +78,6 @@ class PinotTypeCompiler(compiler.GenericTypeCompiler):
     visit_SMALLINT = visit_NUMERIC
     visit_BIGINT = visit_NUMERIC
     visit_BOOLEAN = visit_NUMERIC
-    visit_TIMESTAMP = visit_NUMERIC
     visit_DATE = visit_NUMERIC
 
     def visit_CHAR(self, type_, **kwargs):
@@ -96,6 +95,8 @@ class PinotTypeCompiler(compiler.GenericTypeCompiler):
 
     def visit_DATETIME(self, type_, **kwargs):
         return "TIMESTAMP"
+
+    visit_TIMESTAMP = visit_DATETIME
 
     def visit_TIME(self, type_, **kwargs):
         raise exceptions.NotSupportedError("Type TIME is not supported")

--- a/tests/unit/test_sqlalchemy.py
+++ b/tests/unit/test_sqlalchemy.py
@@ -541,7 +541,7 @@ class PinotTypeCompilerTest(PinotTestCase):
         self.assertEqual(self.compiler.visit_BOOLEAN(None), 'NUMERIC')
 
     def test_compiles_timestamp(self):
-        self.assertEqual(self.compiler.visit_TIMESTAMP(None), 'NUMERIC')
+        self.assertEqual(self.compiler.visit_TIMESTAMP(None), 'TIMESTAMP')
 
     def test_compiles_date(self):
         self.assertEqual(self.compiler.visit_DATE(None), 'NUMERIC')


### PR DESCRIPTION
### What

`PinotTypeCompiler.visit_TIMESTAMP` was aliased to `visit_NUMERIC` (returning `"NUMERIC"`), while `visit_DATETIME` right next to it already correctly returns `"TIMESTAMP"`. Any SQLAlchemy expression that compiles a `TIMESTAMP`-typed value (e.g. `cast(col, TIMESTAMP)`) produced invalid/misleading SQL like `CAST(col AS NUMERIC)` instead of `CAST(col AS TIMESTAMP)`.

`get_type()` a few hundred lines down already maps Pinot's own `"timestamp"` schema dataType to `types.TIMESTAMP` correctly, so the type object itself was right, it was only the reverse direction (type object -> DDL/cast type string) that was wrong.

### Verification

Confirmed live against a Pinot 1.6.0 quickstart:

```python
from sqlalchemy import create_engine, column, TIMESTAMP
from sqlalchemy.sql import cast as sa_cast
engine = create_engine("pinot+http://localhost:8000/query/sql?controller=http://localhost:9000/")
expr = sa_cast(column("some_ts_col"), TIMESTAMP)
str(expr.compile(dialect=engine.dialect))
```

- Before: `CAST(some_ts_col AS NUMERIC)`
- After: `CAST(some_ts_col AS TIMESTAMP)`

Also updated the existing unit test (`test_compiles_timestamp`), which had been asserting the buggy `'NUMERIC'` output. Full unit suite (146 tests) passes.

### Context

Found this while investigating a downstream workaround in Apache Superset's Pinot engine spec ([`superset/db_engine_specs/pinot.py`](https://github.com/apache/superset/blob/master/superset/db_engine_specs/pinot.py)), which special-cases exactly this aliasing with a comment noting it could be removed once the driver fixes it.

I also looked into a second issue in the same area (`Cursor.description` staying `None` for zero-row results when `columnDataTypes` is absent from the broker response) but couldn't reproduce it against current Pinot (1.6.0) + this client in several scenarios (simple filter, GROUP BY, multistage engine, a genuinely empty table with zero segments) — `columnDataTypes` was always present. Not filing anything for that one since I can't demonstrate it; flagging here in case it rings a bell for something version- or config-specific I didn't hit.